### PR TITLE
[TASK] Declare TYPO3 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "^9.5"
+        "typo3/cms-core": "^9.5 || ^10.4"
     },
     "require-dev": {
         "nimut/testing-framework": "4.x-dev"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'typo3' => '9.5.0-9.5.99',
+      'typo3' => '9.5.0-10.4.99',
     ),
     'conflicts' => 
     array (


### PR DESCRIPTION
Resolves #1 

What I did:
- declared compatibility in `ext_emconf.php` and `composer.json` for both TYPO3 9 and 10
- tried it out in a TYPO3 10.4.4 instance:
  - there were no log entries, PHP warnings, deprecations, etc.
  - the extension still does what it should do
  - i could not find any undesired side effects
  - quick glance at extension PHP code does not show any warning signs to me (TYPO3 classes moved etc…)