### PR TITLE
Removed Slot, added Event Listener for compatibility with TYPO3 11.5

### DIFF
--- a/Classes/Listener/TcaColPosListener.php
+++ b/Classes/Listener/TcaColPosListener.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
+
 namespace IchHabRecht\HideUsedContent\Listener;
 
 use IchHabRecht\HideUsedContent\Cache\CacheManager;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TcaColPosListener
 {

--- a/Classes/Listener/TcaColPosListener.php
+++ b/Classes/Listener/TcaColPosListener.php
@@ -1,13 +1,12 @@
 <?php
-
-declare(strict_types=1);
-
-namespace IchHabRecht\HideUsedContent\Slot;
+declare(strict_types = 1);
+namespace IchHabRecht\HideUsedContent\Listener;
 
 use IchHabRecht\HideUsedContent\Cache\CacheManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent;
 
-class TcaColPosSlot
+class TcaColPosListener
 {
     /**
      * @var CacheManager
@@ -17,6 +16,11 @@ class TcaColPosSlot
     public function __construct(CacheManager $cache = null)
     {
         $this->cacheManager = $cache ?: GeneralUtility::makeInstance(CacheManager::class);
+    }
+
+    public function __invoke(AfterTcaCompilationEvent $event)
+    {
+        $this->initializeColPosCache($event->getTca());
     }
 
     public function initializeColPosCache($tca): array

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,6 @@
+services:
+  IchHabRecht\HideUsedContent\Listener\TcaColPosListener:
+    tags:
+      - name: event.listener
+        identifier: 'tcaColPosListener'
+        event: TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": ">= 7.2, < 7.5",
-        "typo3/cms-core": "^9.5 || ^10.4"
+        "php": ">= 7.4, < 7.5",
+        "typo3/cms-core": "^11.4"
     },
     "require-dev": {
         "nimut/testing-framework": "5.x-dev"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,12 +21,12 @@ $EM_CONF[$_EXTKEY] = array (
   'uploadfolder' => 0,
   'createDirs' => '',
   'clearCacheOnLoad' => 0,
-  'version' => '1.0.0',
+  'version' => '2.0.0',
   'constraints' =>
   array (
     'depends' =>
     array (
-      'typo3' => '9.5.0-10.4.99',
+      'typo3' => '11.4.0-11.5.99',
     ),
     'conflicts' =>
     array (

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,4 +1,5 @@
 <?php
+
 defined('TYPO3_MODE') || die('Access denied.');
 
 call_user_func(function () {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,16 +1,7 @@
 <?php
-
 defined('TYPO3_MODE') || die('Access denied.');
 
 call_user_func(function () {
-    $dispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
-    $dispatcher->connect(
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::class,
-        'tcaIsBeingBuilt',
-        \IchHabRecht\HideUsedContent\Slot\TcaColPosSlot::class,
-        'initializeColPosCache'
-    );
-
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['record_is_used']['hide_used_content'] =
         \IchHabRecht\HideUsedContent\Hooks\PageLayoutViewHook::class . '->hideUsedContent';
 });


### PR DESCRIPTION
The slot for the signal tcaIsBeingBuilt doesn't work in TYPO3 11.4 and as Signal/Slots are deprecated, I updated the extension with an event listener.